### PR TITLE
added support for using an existing EntraID SPN

### DIFF
--- a/deployment-tf/azure-aci/0-main.tf
+++ b/deployment-tf/azure-aci/0-main.tf
@@ -77,12 +77,12 @@ resource "azurerm_container_group" "logstash" {
     }
 
     environment_variables = merge(var.environment_variables, {
-      "azure_dcr_microseg_id"  = azurerm_monitor_data_collection_rule.aviatrix_microseg.immutable_id
-      "azure_dcr_suricata_id"  = azurerm_monitor_data_collection_rule.aviatrix_suricata.immutable_id
+      "azure_dcr_microseg_id"    = azurerm_monitor_data_collection_rule.aviatrix_microseg.immutable_id
+      "azure_dcr_suricata_id"    = azurerm_monitor_data_collection_rule.aviatrix_suricata.immutable_id
       "data_collection_endpoint" = azurerm_monitor_data_collection_endpoint.dce.logs_ingestion_endpoint
-      "client_app_id" = azuread_application.logstash_app.client_id
-      "client_app_secret" = azuread_application_password.logstash_app_password.value
-      "tenant_id" = data.azuread_client_config.current.tenant_id
+      "client_app_id"            = var.use_existing_spn ? var.client_app_id : azuread_application.logstash_app[0].client_id
+      "client_app_secret"        = var.use_existing_spn ? var.client_app_secret : azuread_application_password.logstash_app_password[0].value
+      "tenant_id"                = var.use_existing_spn ? var.tenant_id : data.azuread_client_config.current[0].tenant_id
     })
 
     volume {

--- a/deployment-tf/azure-aci/1-service-principal.tf
+++ b/deployment-tf/azure-aci/1-service-principal.tf
@@ -1,0 +1,58 @@
+# Terraform configuration file for EntraID Service Principal and Role Assignments
+# This is optional if you want to use an existing Service Principal instead of creating a new one
+# This is managed by variable "use_existing_spn"
+
+data "azuread_client_config" "current" {
+  count = var.use_existing_spn ? 0 : 1
+}
+
+data "azurerm_client_config" "current" {}
+
+# If using an existing Service Principal, we need to retrieve its object ID
+data "azuread_service_principal" "existing_client_app_id" {
+  count     = var.use_existing_spn ? 1 : 0
+  client_id = var.client_app_id
+}
+
+# 1. Application (Service Principal) creation
+resource "azuread_application" "logstash_app" {
+  count        = var.use_existing_spn ? 0 : 1
+  display_name = "aweiss-logstash-sentinel-${random_integer.suffix.result}"
+  owners       = [data.azuread_client_config.current[0].object_id]
+}
+
+resource "azuread_application_password" "logstash_app_password" {
+  count          = var.use_existing_spn ? 0 : 1
+  application_id = azuread_application.logstash_app[0].id
+  end_date       = timeadd(timestamp(), "8760h")
+
+  lifecycle {
+    ignore_changes = [end_date]
+  }
+}
+
+resource "azuread_service_principal" "logstash_sp" {
+  count     = var.use_existing_spn ? 0 : 1
+  client_id = azuread_application.logstash_app[0].client_id
+  owners    = [data.azuread_client_config.current[0].object_id]
+}
+
+resource "azuread_service_principal_password" "logstash_sp_password" {
+  count                  = var.use_existing_spn ? 0 : 1
+  service_principal_id   = azuread_service_principal.logstash_sp[0].id
+}
+
+# Role assignment for the Log Analytics Data Collection Rules
+resource "azurerm_role_assignment" "aviatrix_suricata_dcr_assignment" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.log_analytics_resource_group_name}/providers/Microsoft.Insights/dataCollectionRules/aviatrix-suricata-dcr"
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = var.use_existing_spn ? data.azuread_service_principal.existing_client_app_id[0].object_id : azuread_service_principal.logstash_sp[0].object_id
+  depends_on           = [azurerm_monitor_data_collection_rule.aviatrix_suricata]
+}
+
+resource "azurerm_role_assignment" "aviatrix_microseg_dcr_assignment" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.log_analytics_resource_group_name}/providers/Microsoft.Insights/dataCollectionRules/aviatrix-microseg-dcr"
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = var.use_existing_spn ? data.azuread_service_principal.existing_client_app_id[0].object_id : azuread_service_principal.logstash_sp[0].object_id
+  depends_on           = [azurerm_monitor_data_collection_rule.aviatrix_microseg]
+}

--- a/deployment-tf/azure-aci/2-data-collection.tf
+++ b/deployment-tf/azure-aci/2-data-collection.tf
@@ -1,3 +1,6 @@
+# Terraform configuration file for Azure Monitor Data Collection Rules and related resources
+
+## Data Collection Endpoint used as entry point for Data Collection Rules
 resource "azurerm_monitor_data_collection_endpoint" "dce" {
   name                = "avx-drc-${random_integer.suffix.result}"
   location            = azurerm_resource_group.aci_rg.location
@@ -5,6 +8,7 @@ resource "azurerm_monitor_data_collection_endpoint" "dce" {
 
 }
 
+## Data Collection Rules for Aviatrix Firewall logs
 resource "azurerm_monitor_data_collection_rule" "aviatrix_microseg" {
   name                = "aviatrix-microseg-dcr"
   location            = azurerm_resource_group.aci_rg.location
@@ -86,6 +90,7 @@ resource "azurerm_monitor_data_collection_rule" "aviatrix_microseg" {
   }
 }
 
+## Data Collection Rules for Aviatrix IDS logs
 resource "azurerm_monitor_data_collection_rule" "aviatrix_suricata" {
   name                = "aviatrix-suricata-dcr"
   location            = azurerm_resource_group.aci_rg.location
@@ -198,86 +203,3 @@ resource "azurerm_monitor_data_collection_rule" "aviatrix_suricata" {
     }
   }
 }
-
-# Azure AD Application and Service Principal for Logstash to authenticate to Azure Monitor DCR
-data "azuread_client_config" "current" {}
-data "azurerm_client_config" "current" {}
-
-# 1. Application (Service Principal) creation
-resource "azuread_application" "logstash_app" {
-  display_name = "aweiss-logstash-sentinel-${random_integer.suffix.result}"
-  owners    = [data.azuread_client_config.current.object_id]
-}
-# 2. Create the password for the created APP
-resource "azuread_application_password" "logstash_app_password" {
-  application_id = azuread_application.logstash_app.id
-  end_date = timeadd(timestamp(), "8760h")
-
-  lifecycle {
-    ignore_changes = [end_date]
-  }
-}
-
-# 3. Create SP associated with the APP
-resource "azuread_service_principal" "logstash_sp" {
-  client_id = azuread_application.logstash_app.client_id
-  owners    = [data.azuread_client_config.current.object_id]
-}
-
-# 4. Create the password for the created SP
-resource "azuread_service_principal_password" "logstash_sp_password" {
-  service_principal_id = azuread_service_principal.logstash_sp.id
-}
-
-# Role assignment for the Log Analytics Data Collection Rules
-
-resource "azurerm_role_assignment" "aviatrix_suricata_dcr_assignment" {
-  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.log_analytics_resource_group_name}/providers/Microsoft.Insights/dataCollectionRules/aviatrix-suricata-dcr"
-  role_definition_name = "Monitoring Metrics Publisher"
-  principal_id         = azuread_service_principal.logstash_sp.object_id
-  depends_on = [ azurerm_monitor_data_collection_rule.aviatrix_suricata ]
-}
-
-resource "azurerm_role_assignment" "aviatrix_microseg_dcr_assignment" {
-  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.log_analytics_resource_group_name}/providers/Microsoft.Insights/dataCollectionRules/aviatrix-microseg-dcr"
-  role_definition_name = "Monitoring Metrics Publisher"
-  principal_id         = azuread_service_principal.logstash_sp.object_id
-  depends_on = [ azurerm_monitor_data_collection_rule.aviatrix_microseg ]
-}
-
-
-## Work in progress - Sample Log Analytics Table for Aviatrix Microseg. Doesn't support TF resource yet.
-# resource "azapi_resource" "aviatrix_microseg_table" {
-#   type      = "Microsoft.OperationalInsights/workspaces/tables@2022-10-01"
-#     parent_id = data.azurerm_log_analytics_workspace.workspace.id
-#   name      = "AviatrixMicroseg_CL"
-
-#   body = jsonencode({
-#     properties = {
-#       schema = {
-#         name    = "AviatrixMicroseg_CL"
-#         columns = [
-#           { name = "TimeGenerated",      type = "DateTime" },
-#           { name = "Computer",           type = "string" },
-#           { name = "action",             type = "string" },
-#           { name = "dst_ip",             type = "string" },
-#           { name = "dst_mac",            type = "string" },
-#           { name = "dst_port",           type = "int" },
-#           { name = "enforced",           type = "boolean" },
-#           { name = "gw_hostname",        type = "string" },
-#           { name = "ls_timestamp",       type = "string" },
-#           { name = "message",            type = "string" },
-#           { name = "proto",              type = "string" },
-#           { name = "src_ip",             type = "string" },
-#           { name = "src_mac",            type = "string" },
-#           { name = "src_port",           type = "int" },
-#           { name = "tags",               type = "dynamic" },
-#           { name = "unix_time",          type = "long" },
-#           { name = "uuid",               type = "string" },
-#           { name = "SourceType",         type = "string" },
-#           { name = "UnixTime",           type = "long" }
-#         ]
-#       }
-#     }
-#   })
-# }

--- a/deployment-tf/azure-aci/terraform.tfvars.sample
+++ b/deployment-tf/azure-aci/terraform.tfvars.sample
@@ -19,6 +19,12 @@ storage_account_name   = "yourstorageaccount"
 log_analytics_workspace_name        = "your-log-analytics-workspace"
 log_analytics_resource_group_name   = "your-log-analytics-rg"
 
+# If you use your own EntraID Service Principal, uncomment the below and insert appropriate value
+# client_app_id                  = "00000000-0000-0000-0000-000000000000"
+# client_app_secret                  = "fake-client-secret"
+# tenant_id                      = "00000000-0000-0000-0000-000000000000"
+# use_existing_spn                   = false
+
 # Tags
 tags = {
   Usage = "Aviatrix"

--- a/deployment-tf/azure-aci/variables.tf
+++ b/deployment-tf/azure-aci/variables.tf
@@ -128,3 +128,28 @@ variable "logstash_config_variables" {
     "tenant_id" = "your-tenant-id"
   }
 }
+
+variable "use_existing_spn" {
+  description = "Whether to use an existing service principal (true) or create a new one (false) for the plugin to send logs to Log Analytics via DCR rules"
+  type        = bool
+  default     = true
+}
+
+variable "client_app_id" {
+  description = "Client Application ID for authentication"
+  type        = string
+  default     = "dummy"
+}
+
+variable "client_app_secret" {
+  description = "Client Application Secret for authentication"
+  type        = string
+  default     = "dummy"
+  sensitive   = true
+}
+
+variable "tenant_id" {
+  description = "Tenant ID for authentication"
+  type        = string
+  default     = "dummy"
+}


### PR DESCRIPTION
Customer's ask:
- added support for using an existing EntraID SPN or use the terraform deployment to create one for you if you have appropriate access rights to Entra ID
- removed some useless doc chapters